### PR TITLE
gulp build:dist aint copying index.html , a gulp task for doing the same.

### DIFF
--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -43,9 +43,15 @@ gulp.task('build', ['clean'], (cb) => {
   RunSequnence(['assets', 'bundle'], cb)
 });
 
+gulp.task('copyIndex', (cb) => {
+  return gulp.src(['src/index.html'])
+    .pipe($.replace('assets/main.js', 'main.js'))
+    .pipe(gulp.dest('dist/'));
+});
+
 gulp.task('build:dist', ['clean'], (cb) => {
   options.dist = true;
-  RunSequnence(['assets', 'bundle'], cb)
+  RunSequnence(['assets', 'bundle', 'copyIndex'], cb)
 });
 
 gulp.task('build:watch', ['clean'], (cb) => {

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "gulp": "^3.9.0",
     "gulp-load-plugins": "^1.0.0-rc.1",
     "gulp-serve": "^1.0.0",
+    "gulp-replace": "^0.5.4",
     "gulp-size": "^2.0.0",
     "http-proxy": "^1.11.1",
     "raw-loader": "^0.5.1",


### PR DESCRIPTION
Fix for issue #5 . Build task ain't copying index.Html file .This pull-request contains a gulp task for doing the same . how ever index.html points to assets/main.js , so piped index.html to a gulp-replace task that change the script tag to load it from ./main.js , as both main.js and index.html will directly be under dist folder as per existing structure
