### PR TITLE
Serve static files on dev server

### DIFF
--- a/scripts/server.js
+++ b/scripts/server.js
@@ -18,6 +18,7 @@ app.use(require('webpack-dev-middleware')(compiler, {
 
 app.use(require('webpack-hot-middleware')(compiler));
 app.use('api', require('../src/mock'));
+app.use(express.static(path.resolve(__dirname, '../src/public')));
 
 app.listen(3000, 'localhost', (err) => {
   if (err) {


### PR DESCRIPTION
This is a minor change the mirror the build on production, serving files from `src/public` to static site.
